### PR TITLE
Build an AppImage on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: minimal
+dist: xenial
+
+env:
+  global:
+    - DISPLAY=:99
+
+matrix:
+  include:
+    - name: "Build for x86_64"
+      env: ARCH=x86_64
+
+before_install:
+  - sudo add-apt-repository ppa:alexlarsson/flatpak -y
+  - sudo apt-get update -q
+  - sudo apt-get -y install flatpak xvfb x11-xserver-utils imagemagick
+
+install:
+  - sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+  - sudo flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+
+script:
+  - Xvfb :99 -screen 0 800x600x24 >/dev/null 2>&1 &
+  - sudo flatpak install -v --noninteractive flathub org.gnome.gedit # Why is --system needed? Why not --user?
+  - sudo bash -ex ./flatpak2appdir org.gnome.gedit # Why is sudo needed?
+  - ls -lh
+  - wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+  - chmod +x appimagetool-*.AppImage
+  - find ./*.AppDir -wholename 'usr/share/icons' # FIXME
+  - convert org.gnome.gedit.AppDir/app/share/icons/hicolor/scalable/apps/org.gnome.gedit.svg -resize 128x128 ./org.gnome.gedit.AppDir/org.gnome.gedit.png # FIXME in appimagetool
+  # This Flatpak does not have an 1.0-compliant desktop file, hence we need to patch it on the fly
+  - sed -i -e 's|Text Editor|Gedit|g' org.gnome.gedit.AppDir/app/share/applications/org.gnome.gedit.desktop # FIXME, can we get the real application name from AppStream metainfo?
+  - sed -i -e 's|Keywords\[|X-Keywords\[|g' org.gnome.gedit.AppDir/app/share/applications/org.gnome.gedit.desktop
+  - sed -i -e 's|DBusActivatable|X-DBusActivatable|g' org.gnome.gedit.AppDir/app/share/applications/org.gnome.gedit.desktop
+  - cp org.gnome.gedit.AppDir/app/share/applications/org.gnome.gedit.desktop ./org.gnome.gedit.AppDir/ # FIXME in flatpak2appdir
+  - grep "Exec=.*" ./*.AppDir/*.desktop | head -n 1 | cut -d "=" -f 2 | cut -d " " -f 1 > org.gnome.gedit.AppDir/command # FIXME in flatpak2appdir
+  # TODO: Automatically determine and export $VERSION
+  - find org.gnome.gedit.AppDir
+  - mv ./org.gnome.gedit.AppDir/start-app.sh ./org.gnome.gedit.AppDir/AppRun # FIXME in flatpak2appdir
+  - VERSION=1.0 ./appimagetool-*.AppImage ./*.AppDir # turn AppDir into AppImage
+
+after_script:
+  - killall Xvfb
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh Gedit*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ chmod +x flatpak2appdir
 
 5. Run as root:
 ```
-sudo ./atpak2appdir com.example.app
+sudo ./flatpak2appdir com.example.app
 ```
 > Note: to do these steps `flatpak2appdir` will create a `.img` file with the runtime name, you can delete this **after** AppDir creation
 # How to use?

--- a/flatpak2appdir
+++ b/flatpak2appdir
@@ -50,7 +50,7 @@ sudo mount -o loop,strictatime,nodiratime ${runtime_name}_${runtime_version}.img
 echo "[ 3/7 ] Copying runtime to image"
 [ ! -f "${mount_point}/bin/bash" ] && {
   sudo mkdir -p ${mount_point}/usr
-  sudo sudo cp -vr ${runtime}/* ${mount_point}/usr
+  sudo sudo cp -r ${runtime}/* ${mount_point}/usr
   sudo ln -s usr/bin   ${mount_point}/bin
   sudo ln -s usr/lib   ${mount_point}/lib
   sudo ln -s usr/lib64 ${mount_point}/lib64
@@ -84,7 +84,10 @@ chmod +x ${mount_point}/AppRun
 
 echo "[ 7/7 ] Copying used files..."
 touch ${mount_point}/test
-chroot ${mount_point} /AppRun ${command}
+chroot ${mount_point} /AppRun ${command} &
+APID=$!
+sleep 15
+kill $APID
 mkdir -p ${1}.AppDir
 find ${mount_point} -mindepth 3 -anewer ${mount_point}/test -not -path '*/proc/*' -not -path '*/home/*' | sed 's/^/cp -P --parents /g' | sed "s|$| ${1}.AppDir|g" | sh
 cp -r ${mount_point}/app ${1}.AppDir
@@ -101,9 +104,12 @@ cp ${HERE}/start-app.sh ${1}.AppDir
 chmod -R a+rwx ${1}.AppDir/
 
 echo "[ 7/7 ] Finishing..."
-umount ${mount_point}
-umount ${mount_point}/app
-umount ${mount_point}/proc
-umount ${mount_point}
+sleep 1
+sync
+sleep 1
+# umount -l ${mount_point}
+umount -l ${mount_point}/app
+umount -l ${mount_point}/proc
+umount -l ${mount_point}
 
 rm -rfv ${mount_point}


### PR DESCRIPTION
Great work @sudo-give-me-coffee, let's create the virtual counterpart of  https://www.ikea.com/ms/en_US/customer-service/our-services/assembly.html :-)

![20172_cvav02a_assembly](https://user-images.githubusercontent.com/2480569/76938176-0f837500-68ee-11ea-875e-00f591d5bc00.jpg)

This pull request, when merged, builds an AppImage on Travis CI and uploads it to GitHub Releases.

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

Here is an AppImage for testing:
https://github.com/probonopd/flatpak2appdir/releases/tag/continuous

![](https://user-images.githubusercontent.com/2480569/76938433-815bbe80-68ee-11ea-88d5-bcc9f2bcd56a.png)

Now it should be a matter of removing the need for the `FIXME`s in `.travis.yml` and getting it to work for other applications as well.